### PR TITLE
Allow symbols as constructor names

### DIFF
--- a/fixtures/fitnesse.fixtures.js
+++ b/fixtures/fitnesse.fixtures.js
@@ -24,10 +24,21 @@ function EchoFixture(){
     this.echo = function(echo,cb){
         cb(null,echo);
     }
+
+    this.echoInt = function(i,cb) {
+        cb(null,i);
+    }
+}
+
+function TestSlim() {
     this.echoBoolean = function(b,cb){
         cb(null,b);
     }
-    this.echoInt = function(i,cb) {
-        cb(null,i);
+    this.setString = function(s, cb){
+        this._s = s;
+        cb(null,null);
+    }
+    this.getStringArg = function (cb) {
+        cb(null,this._s);
     }
 }

--- a/src/instructions.js
+++ b/src/instructions.js
@@ -39,11 +39,17 @@ proto.make = function (ins, cb) {
     var instance = ins[2];
     var clazz = ins[3];
 
-    if(clazz.indexOf('$')===0 && (typeof Symbols[clazz] !== 'string'))
-    {
-        LOG("Copy Symbol: " + instance + " "  + clazz);
-        ObjectPool[instance] = Symbols[clazz.substr(1)];
-        return cb([id,'OK'])
+    if (clazz.indexOf('$')===0) {
+        var symbol = Symbols[clazz.substr(1)];
+        if (typeof symbol === 'string')
+        {
+            LOG("Use Symbol as class name: " + " "  + clazz);
+            clazz = symbol;
+        } else {
+            LOG("Copy Symbol: " + instance + " "  + clazz);
+            ObjectPool[instance] = symbol;
+            return cb([id,'OK'])
+        }
     }
 
     var args = ins.slice(4);


### PR DESCRIPTION
It now handles the case, when the symbol makes up the complete constructor name.
It does not work yet, if the symbol is in the middle of the string.
Test$QUERY should evaluate to TestQuery in FitNesse.SuiteAcceptanceTests.SuiteSlimTests.ChainTest

Take a look at the Java Fixtures in
https://github.com/unclebob/fitnesse/tree/master/src/fitnesse/slim/test

There is no echoBoolean in EchoFixture
https://github.com/unclebob/fitnesse/blob/master/src/fitnesse/fixtures/EchoFixture.java

