### PR TITLE
Added support for symbols into constructors

### DIFF
--- a/src/exec/CallExecutor.js
+++ b/src/exec/CallExecutor.js
@@ -24,7 +24,7 @@ function CallExecutor(state){
             if (!theFunc && isOptionalFunction(funName))
                 return cb([id, VOID]);
 
-            loadSybolValuesToArguments(args);
+            state.loadSymbolValuesToArguments(args);
 
             if(!theFunc)
                 tryToGetSUT();
@@ -88,13 +88,6 @@ function CallExecutor(state){
 
         this.call(instructionArgument, cb, symbolName);
     };
-
-
-    function loadSybolValuesToArguments(args) {
-        for (var i = 0; i < args.length; i++)
-            if (args[i].toString().indexOf('$') === 0)
-                args[i] = state.getSymbol(args[i].substr(1));
-    }
 
     function isPromise(obj) {
         return obj.then && typeof obj.then === 'function';

--- a/src/exec/ExecutionManager.js
+++ b/src/exec/ExecutionManager.js
@@ -58,6 +58,12 @@ function ExecutionManager(arrayOfSearchPaths){
         return null;
     }
 
+    this.loadSymbolValuesToArguments = function(args){
+        for (var i = 0; i < args.length; i++)
+            if (args[i].toString().indexOf('$') === 0)
+                args[i] = this.getSymbol(args[i].substr(1));
+    }
+
     function hasSutFunction(instance){
         if(!instance)
             return false;

--- a/src/exec/MakeExecutor.js
+++ b/src/exec/MakeExecutor.js
@@ -24,6 +24,8 @@ function MakeExecutor(state){
 
         var args = instructionArgument.slice(4);
 
+        state.loadSymbolValuesToArguments(args);
+
         state.makeInstance(clazz, args,function(err,obj){
             if (err)
                 return cb([id, utils.toException(err)]);


### PR DESCRIPTION
Symbols (variables) should be supported as constructor arguments according to the fitnesse documentation. This fixes this behavior.