### PR TITLE
Fixed hanging a test included unicode chars.

### DIFF
--- a/src/tcp/ConnectionHandler.js
+++ b/src/tcp/ConnectionHandler.js
@@ -66,7 +66,7 @@ function ConnectionHandler(){
     }
 
     function payloadBodyHasArrived() {
-        return buffer.length - lenHeader.length == payloadLength;
+        return Buffer.byteLength(buffer, 'utf8') - lenHeader.length == payloadLength;
     }
 
     function executeInstructionSet(t){

--- a/src/tcp/SlimParser.js
+++ b/src/tcp/SlimParser.js
@@ -15,7 +15,7 @@ function SlimParser() {
     this.stringify = function (arr) {
         var arr = arrayToSlim(arr);
 
-        var result = pad(arr.length + 2) + ":[" + arr + "]";
+        var result = pad(Buffer.byteLength(arr, 'utf8') + 2) + ":[" + arr + "]";
 
         return result;
     }


### PR DESCRIPTION
Use `Buffer.byteLength` instead of `lenth` to fix it.

### Example to see the issue

#### Test page
```
!define TEST_SYSTEM {slim}
!define COMMAND_PATTERN {SlimJS %p}
!path /Path/To/My/Fixtures

|import      |
|my-test-file|

|Hi            |
|echo |sayHi?  |
|Bob  |안녕! Bob |
```

#### Fixture (/Path/To/My/Fixtures/my-test-file.js)

```
function Hi(){
    this.setEcho = function(str){
        this.echo = str;
    }

    this.sayHi = function(){
        return "안녕! " + this.echo; // unicode
    }
}

module.exports.Hi = Hi;
```

#### Result : execution log

```
Internal Exceptions:

Could not send/receive data with SUT

fitnesse.testsystems.slim.SlimCommunicationException: Could not send/receive data with SUT
```