### PR TITLE
use import instead of require

### DIFF
--- a/src/TestCodeLoader.js
+++ b/src/TestCodeLoader.js
@@ -36,9 +36,9 @@ function TestCodeLoader(arrayOfSearchPaths){
         }
     }
 
-    function loadFixture(file,cb){
+    async function loadFixture(file,cb){
         try {
-            theRequireArrayOfTheTestFixtures.push(require(file));
+            theRequireArrayOfTheTestFixtures.push(await import(file));
             cb(null);
         }
         catch (e) {


### PR DESCRIPTION
According to official docs:
An import statement can reference an ES module or a CommonJS module.
import statements are permitted only in ES modules, but dynamic import()
expressions are supported in CommonJS for loading ES modules.